### PR TITLE
feat(ext/http) Optional websocket header response

### DIFF
--- a/ext/http/01_http.js
+++ b/ext/http/01_http.js
@@ -39,6 +39,7 @@ const {
 import { InnerBody } from "ext:deno_fetch/22_body.js";
 import { Event, setEventTargetData } from "ext:deno_web/02_event.js";
 import { BlobPrototype } from "ext:deno_web/09_file.js";
+import { headerListFromHeaders, headersFromHeaderList } from "ext:deno_fetch/20_headers.js";
 import {
   fromInnerResponse,
   newInnerResponse,
@@ -458,7 +459,11 @@ function upgradeWebSocket(request, options = {}) {
   }
 
   if (options.headers) {
-    for (const h of options.headers) {
+    const headers = headersFromHeaderList(
+      headerListFromHeaders(options.headers),
+      'response'
+    );
+    for (const h of headers) {
       ArrayPrototypePush(r.headerList, [h[0], h[1]]);
     }
   }


### PR DESCRIPTION
original issue [#19277](https://github.com/denoland/deno/issues/19277)
work on top of PR [#22242](https://github.com/denoland/deno/pull/22242)

I'm not sure what the preferred workflow is to work off of someone else's PR from a their fork, so please let me know if there is a better way for me to submit this type of work in the future!

I've applied 1/2 of @mmastrac 's requested changes https://github.com/denoland/deno/pull/22242#pullrequestreview-1888495439

I'm not sure how to:

> add it to lib.deno.unstable.d.ts and ensure that the correct unstable flag is passed